### PR TITLE
Feat: expose samples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ test-fail-warning = []
 thiserror = "2.0"
 paste = "1.0"
 flume = "0.11"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 cidre = { git = "https://github.com/yury/cidre", rev = "1e008bec49a0f97aeaaea6130a0ba20fe00aa03b", default-features = false, features = [
 	"private",
 	"blocks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,18 @@ test-fail-warning = []
 thiserror = "2.0"
 paste = "1.0"
 flume = "0.11"
+core-media-sys = "0.1"
+cidre = { git = "https://github.com/yury/cidre", rev = "1e008bec49a0f97aeaaea6130a0ba20fe00aa03b", default-features = false, features = [
+	"private",
+	"blocks",
+	"async",
+	"av",
+	"ca",
+	"cm",
+	"dispatch",
+	"macos_13_0",
+] }
+
 
 [dependencies.nokhwa-core]
 version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ test-fail-warning = []
 thiserror = "2.0"
 paste = "1.0"
 flume = "0.11"
-core-media-sys = "0.1"
 cidre = { git = "https://github.com/yury/cidre", rev = "1e008bec49a0f97aeaaea6130a0ba20fe00aa03b", default-features = false, features = [
 	"private",
 	"blocks",

--- a/examples/threaded-capture/Cargo.toml
+++ b/examples/threaded-capture/Cargo.toml
@@ -14,4 +14,4 @@ default-features = false
 [dependencies.nokhwa]
 path = "../.."
 # EDIT THIS!
-features = ["input-native", "output-threaded"]
+features = ["input-avfoundation", "output-threaded"]

--- a/examples/threaded-capture/Cargo.toml
+++ b/examples/threaded-capture/Cargo.toml
@@ -13,5 +13,20 @@ default-features = false
 
 [dependencies.nokhwa]
 path = "../.."
-# EDIT THIS!
-features = ["input-avfoundation", "output-threaded"]
+default-features = false
+features = ["output-threaded"]
+
+[target.'cfg(target_os = "macos")'.dependencies.nokhwa]
+path = "../.."
+default-features = false
+features = ["output-threaded", "input-avfoundation"]
+
+[target.'cfg(target_os = "windows")'.dependencies.nokhwa]
+path = "../.."
+default-features = false
+features = ["output-threaded", "input-msmf"]
+
+[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies.nokhwa]
+path = "../.."
+default-features = false
+features = ["output-threaded", "input-native"]

--- a/examples/threaded-capture/src/main.rs
+++ b/examples/threaded-capture/src/main.rs
@@ -35,6 +35,9 @@ fn main() {
     let first_camera = cameras.first().unwrap();
 
     let mut threaded = CallbackCamera::new(first_camera.index().clone(), format, |buffer| {
+        if let Some(ref buf) = buffer.sample_buf {
+            println!("Sample Buffer: {:?}", buf);
+        }
         let image = buffer.decode_image::<RgbAFormat>().unwrap();
         println!("{}x{} {}", image.width(), image.height(), image.len());
     })

--- a/examples/threaded-capture/src/main.rs
+++ b/examples/threaded-capture/src/main.rs
@@ -35,9 +35,6 @@ fn main() {
     let first_camera = cameras.first().unwrap();
 
     let mut threaded = CallbackCamera::new(first_camera.index().clone(), format, |buffer| {
-        if let Some(ref buf) = buffer.sample_buf {
-            println!("Sample Buffer: {:?}", buf);
-        }
         let image = buffer.decode_image::<RgbAFormat>().unwrap();
         println!("{}x{} {}", image.width(), image.height(), image.len());
     })

--- a/nokhwa-bindings-macos/Cargo.toml
+++ b/nokhwa-bindings-macos/Cargo.toml
@@ -16,6 +16,16 @@ version = "0.1"
 path = "../nokhwa-core"
 
 [target.'cfg(any(target_os="macos",target_os="ios"))'.dependencies]
+cidre = { git = "https://github.com/yury/cidre", rev = "1e008bec49a0f97aeaaea6130a0ba20fe00aa03b", default-features = false, features = [
+	"private",
+	"blocks",
+	"async",
+	"av",
+	"ca",
+	"cm",
+	"dispatch",
+	"macos_13_0",
+] }
 core-media-sys = "0.1"
 core-video-sys = "0.1"
 cocoa-foundation = "0.1"

--- a/nokhwa-bindings-macos/src/lib.rs
+++ b/nokhwa-bindings-macos/src/lib.rs
@@ -209,6 +209,10 @@ mod internal {
     };
 
     use block::ConcreteBlock;
+    use cidre::{
+        arc::Retained,
+        cm::{self, SampleBuf},
+    };
     use cocoa_foundation::{
         base::Nil,
         foundation::{NSArray, NSDictionary, NSInteger, NSString, NSUInteger},
@@ -415,9 +419,7 @@ mod internal {
             ) {
                 let image_buffer: CVImageBufferRef =
                     unsafe { CMSampleBufferGetImageBuffer(didOutputSampleBuffer) };
-                unsafe {
-                    CVPixelBufferLockBaseAddress(image_buffer, 0);
-                };
+                unsafe { CVPixelBufferLockBaseAddress(image_buffer, 0) };
 
                 let buffer_length = unsafe { CVPixelBufferGetDataSize(image_buffer) };
                 let buffer_ptr = unsafe { CVPixelBufferGetBaseAddress(image_buffer) };
@@ -427,15 +429,22 @@ mod internal {
                 };
 
                 unsafe { CVPixelBufferUnlockBaseAddress(image_buffer, 0) };
+
+                let sample_buf = didOutputSampleBuffer as *const cidre::cm::SampleBuf;
+                let sample_buf = unsafe { &*sample_buf };
+
                 // oooooh scarey unsafe
                 // AAAAAAAAAAAAAAAAAAAAAAAAA
                 // https://c.tenor.com/0e_zWtFLOzQAAAAC/needy-streamer-overload-needy-girl-overdose.gif
                 let bufferlck_cv: *const c_void = unsafe { msg_send![this, bufferPtr] };
                 let buffer_sndr = unsafe {
-                    let ptr = bufferlck_cv.cast::<Sender<(Vec<u8>, FrameFormat)>>();
+                    let ptr =
+                        bufferlck_cv.cast::<Sender<(Vec<u8>, FrameFormat, Retained<SampleBuf>)>>();
                     Arc::from_raw(ptr)
                 };
-                if let Err(_) = buffer_sndr.send((buffer_as_vec, FrameFormat::GRAY)) {
+                if let Err(_) =
+                    buffer_sndr.send((buffer_as_vec, FrameFormat::GRAY, sample_buf.retained()))
+                {
                     // FIXME: dont, what the fuck???
                     return;
                 }
@@ -572,9 +581,7 @@ mod internal {
                 AVCaptureDeviceType::TrueDepth => {
                     str_to_nsstr("AVCaptureDeviceTypeBuiltInTrueDepthCamera")
                 }
-                AVCaptureDeviceType::External => {
-                    str_to_nsstr("AVCaptureDeviceTypeExternal")
-                }
+                AVCaptureDeviceType::External => str_to_nsstr("AVCaptureDeviceTypeExternal"),
             }
         }
     }
@@ -683,7 +690,7 @@ mod internal {
     impl AVCaptureVideoCallback {
         pub fn new(
             device_spec: &CStr,
-            buffer: &Arc<Sender<(Vec<u8>, FrameFormat)>>,
+            buffer: &Arc<Sender<(Vec<u8>, FrameFormat, Retained<SampleBuf>)>>,
         ) -> Result<Self, NokhwaError> {
             let cls = &CALLBACK_CLASS as &Class;
             let delegate: *mut Object = unsafe { msg_send![cls, alloc] };
@@ -2303,7 +2310,7 @@ mod internal {
     }
 
     use cocoa_foundation::base::nil;
-    use core_foundation::base::TCFType;
+    use core_foundation::base::{CFRetain, TCFType};
     use core_foundation::number::CFNumber;
     use core_video_sys::kCVPixelBufferPixelFormatTypeKey;
     impl Default for AVCaptureVideoDataOutput {

--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -1123,7 +1123,7 @@ pub mod wmf {
             Ok(())
         }
 
-        pub fn raw_bytes(&mut self) -> Result<Cow<[u8]>, NokhwaError> {
+        pub fn raw_bytes(&mut self) -> Result<(Cow<[u8]>, IMFSample), NokhwaError> {
             let mut imf_sample: Option<IMFSample> = match unsafe { MFCreateSample() } {
                 Ok(sample) => Some(sample),
                 Err(why) => {
@@ -1185,16 +1185,14 @@ pub mod wmf {
             }
 
             let mut data_slice = Vec::with_capacity(buffer_valid_length as usize);
-
             unsafe {
-                // Copy pointer because we're bout to drop IMFSample
-                data_slice.extend_from_slice(std::slice::from_raw_parts_mut(
+                data_slice.extend_from_slice(std::slice::from_raw_parts(
                     buffer_start_ptr,
                     buffer_valid_length as usize,
-                ) as &[u8]);
+                ));
             }
 
-            Ok(Cow::from(data_slice))
+            Ok((Cow::from(data_slice), imf_sample))
         }
 
         pub fn stop_stream(&mut self) {

--- a/nokhwa-core/Cargo.toml
+++ b/nokhwa-core/Cargo.toml
@@ -22,6 +22,16 @@ test-fail-warnings = []
 [dependencies]
 thiserror = "2.0"
 bytes = "1.3"
+cidre = { git = "https://github.com/yury/cidre", rev = "1e008bec49a0f97aeaaea6130a0ba20fe00aa03b", default-features = false, features = [
+	"private",
+	"blocks",
+	"async",
+	"av",
+	"ca",
+	"cm",
+	"dispatch",
+	"macos_13_0",
+] }
 
 [dependencies.image]
 version = "0.25"

--- a/nokhwa-core/Cargo.toml
+++ b/nokhwa-core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/l1npengtul/nokhwa"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["mjpeg"]
 serialize = ["serde"]
 wgpu-types = ["wgpu"]
 mjpeg = ["mozjpeg"]
@@ -18,10 +18,15 @@ opencv-mat = ["opencv", "opencv/clang-runtime", "bytemuck"]
 docs-features = ["serialize", "wgpu-types", "mjpeg"]
 test-fail-warnings = []
 
+[target.'cfg(target_os="windows")'.dependencies.windows]
+version = "0.43"
+features = ["Win32_Media_MediaFoundation"]
 
 [dependencies]
 thiserror = "2.0"
 bytes = "1.3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 cidre = { git = "https://github.com/yury/cidre", rev = "1e008bec49a0f97aeaaea6130a0ba20fe00aa03b", default-features = false, features = [
 	"private",
 	"blocks",

--- a/nokhwa-core/src/buffer.rs
+++ b/nokhwa-core/src/buffer.rs
@@ -40,9 +40,9 @@ pub struct Buffer {
     buffer: Bytes,
     source_frame_format: FrameFormat,
     #[cfg(target_os = "macos")]
-    pub sample_buf: Option<Retained<SampleBuf>>,
+    pub raw_sample: Option<Retained<SampleBuf>>,
     #[cfg(target_os = "windows")]
-    pub imf_sample: Option<IMFSample>,
+    pub raw_sample: Option<IMFSample>,
 }
 
 unsafe impl Send for Buffer {}
@@ -56,19 +56,17 @@ impl Buffer {
         res: Resolution,
         buf: &[u8],
         source_frame_format: FrameFormat,
-        #[cfg(target_os = "macos")]
-        sample_buf: Option<Retained<SampleBuf>>,
-        #[cfg(target_os = "windows")]
-        imf_sample: Option<IMFSample>,
+        #[cfg(target_os = "macos")] raw_sample: Option<Retained<SampleBuf>>,
+        #[cfg(target_os = "windows")] raw_sample: Option<IMFSample>,
     ) -> Self {
         Self {
             resolution: res,
             buffer: Bytes::copy_from_slice(buf),
             source_frame_format,
             #[cfg(target_os = "macos")]
-            sample_buf,
+            raw_sample,
             #[cfg(target_os = "windows")]
-            imf_sample
+            raw_sample,
         }
     }
 

--- a/nokhwa-core/src/buffer.rs
+++ b/nokhwa-core/src/buffer.rs
@@ -21,10 +21,13 @@ use crate::{
     types::{FrameFormat, Resolution},
 };
 use bytes::Bytes;
+#[cfg(target_os = "macos")]
 use cidre::{arc::Retained, cm::SampleBuf};
 use image::ImageBuffer;
 #[cfg(feature = "opencv-mat")]
 use opencv::{boxed_ref::BoxedRef, core::Mat};
+#[cfg(target_os = "windows")]
+use windows::Win32::Media::MediaFoundation::IMFSample;
 
 /// A buffer returned by a camera to accommodate custom decoding.
 /// Contains information of Resolution, the buffer's [`FrameFormat`], and the buffer.
@@ -38,7 +41,12 @@ pub struct Buffer {
     source_frame_format: FrameFormat,
     #[cfg(target_os = "macos")]
     pub sample_buf: Option<Retained<SampleBuf>>,
+    #[cfg(target_os = "windows")]
+    pub imf_sample: Option<IMFSample>,
 }
+
+unsafe impl Send for Buffer {}
+unsafe impl Sync for Buffer {}
 
 impl Buffer {
     /// Creates a new buffer with a [`&[u8]`].
@@ -48,13 +56,19 @@ impl Buffer {
         res: Resolution,
         buf: &[u8],
         source_frame_format: FrameFormat,
+        #[cfg(target_os = "macos")]
         sample_buf: Option<Retained<SampleBuf>>,
+        #[cfg(target_os = "windows")]
+        imf_sample: Option<IMFSample>,
     ) -> Self {
         Self {
             resolution: res,
             buffer: Bytes::copy_from_slice(buf),
             source_frame_format,
+            #[cfg(target_os = "macos")]
             sample_buf,
+            #[cfg(target_os = "windows")]
+            imf_sample
         }
     }
 

--- a/nokhwa-core/src/buffer.rs
+++ b/nokhwa-core/src/buffer.rs
@@ -1,3 +1,5 @@
+use std::{ffi::c_void, sync::Arc};
+
 /*
  * Copyright 2022 l1npengtul <l1npengtul@protonmail.com> / The Nokhwa Contributors
  *
@@ -19,6 +21,7 @@ use crate::{
     types::{FrameFormat, Resolution},
 };
 use bytes::Bytes;
+use cidre::{arc::Retained, cm::SampleBuf};
 use image::ImageBuffer;
 #[cfg(feature = "opencv-mat")]
 use opencv::{boxed_ref::BoxedRef, core::Mat};
@@ -27,22 +30,31 @@ use opencv::{boxed_ref::BoxedRef, core::Mat};
 /// Contains information of Resolution, the buffer's [`FrameFormat`], and the buffer.
 ///
 /// Note that decoding on the main thread **will** decrease your performance and lead to dropped frames.
-#[derive(Clone, Debug, Hash, PartialOrd, PartialEq, Eq)]
+// #[derive(Clone, Debug, Hash, PartialOrd, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct Buffer {
     resolution: Resolution,
     buffer: Bytes,
     source_frame_format: FrameFormat,
+    #[cfg(target_os = "macos")]
+    pub sample_buf: Option<Retained<SampleBuf>>,
 }
 
 impl Buffer {
     /// Creates a new buffer with a [`&[u8]`].
     #[must_use]
     #[inline]
-    pub fn new(res: Resolution, buf: &[u8], source_frame_format: FrameFormat) -> Self {
+    pub fn new(
+        res: Resolution,
+        buf: &[u8],
+        source_frame_format: FrameFormat,
+        sample_buf: Option<Retained<SampleBuf>>,
+    ) -> Self {
         Self {
             resolution: res,
             buffer: Bytes::copy_from_slice(buf),
             source_frame_format,
+            sample_buf,
         }
     }
 
@@ -117,9 +129,7 @@ impl Buffer {
     /// Most notably, the `data` **must** stay in scope for the duration of the [`Mat`](https://docs.rs/opencv/latest/opencv/core/struct.Mat.html) or bad, ***bad*** things happen.
     #[cfg(feature = "opencv-mat")]
     #[cfg_attr(feature = "docs-features", doc(cfg(feature = "opencv-mat")))]
-    pub fn decode_opencv_mat<F: FormatDecoder>(
-        &mut self,
-    ) -> Result<BoxedRef<Mat>, NokhwaError> {
+    pub fn decode_opencv_mat<F: FormatDecoder>(&mut self) -> Result<BoxedRef<Mat>, NokhwaError> {
         use crate::buffer::channel_defs::make_mat;
 
         make_mat::<F>(self.resolution, self.buffer())
@@ -137,11 +147,11 @@ impl Buffer {
         &mut self,
         dst: &mut Mat,
     ) -> Result<(), NokhwaError> {
+        use bytes::Buf;
         use image::Pixel;
         use opencv::core::{
             Mat, MatTraitConst, MatTraitManual, Scalar, CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4,
         };
-        use bytes::Buf;
 
         let array_type = match F::Output::CHANNEL_COUNT {
             1 => CV_8UC1,
@@ -221,23 +231,45 @@ impl Buffer {
 /// You (probably) shouldn't use this.
 #[cfg(feature = "opencv-mat")]
 pub mod channel_defs {
-    use bytemuck::{cast_slice, Pod, Zeroable};
-    use image::Pixel;
     use crate::error::NokhwaError;
     use crate::pixel_format::FormatDecoder;
     use crate::types::{FrameFormat, Resolution};
+    use bytemuck::{cast_slice, Pod, Zeroable};
+    use image::Pixel;
 
     #[cfg(feature = "opencv-mat")]
     #[cfg_attr(feature = "docs-features", doc(cfg(feature = "opencv-mat")))]
-    pub(crate) fn make_mat<F>(resolution: Resolution, data: &[u8]) -> Result<opencv::boxed_ref::BoxedRef<opencv::core::Mat>, NokhwaError> where F: FormatDecoder {
+    pub(crate) fn make_mat<F>(
+        resolution: Resolution,
+        data: &[u8],
+    ) -> Result<opencv::boxed_ref::BoxedRef<opencv::core::Mat>, NokhwaError>
+    where
+        F: FormatDecoder,
+    {
         use crate::buffer::channel_defs::*;
         use opencv::core::Mat;
 
         let mat = match F::Output::CHANNEL_COUNT {
-            1 => Mat::new_rows_cols_with_data::<G8>(resolution.width() as i32, resolution.height() as i32, cast_slice(data)),
-            2 => Mat::new_rows_cols_with_data::<GA8>(resolution.width() as i32, resolution.height() as i32, cast_slice(data)),
-            3 => Mat::new_rows_cols_with_data::<RGB8>(resolution.width() as i32, resolution.height() as i32, cast_slice(data)),
-            4 => Mat::new_rows_cols_with_data::<RGBA8>(resolution.width() as i32, resolution.height() as i32, cast_slice(data)),
+            1 => Mat::new_rows_cols_with_data::<G8>(
+                resolution.width() as i32,
+                resolution.height() as i32,
+                cast_slice(data),
+            ),
+            2 => Mat::new_rows_cols_with_data::<GA8>(
+                resolution.width() as i32,
+                resolution.height() as i32,
+                cast_slice(data),
+            ),
+            3 => Mat::new_rows_cols_with_data::<RGB8>(
+                resolution.width() as i32,
+                resolution.height() as i32,
+                cast_slice(data),
+            ),
+            4 => Mat::new_rows_cols_with_data::<RGBA8>(
+                resolution.width() as i32,
+                resolution.height() as i32,
+                cast_slice(data),
+            ),
             _ => {
                 return Err(NokhwaError::ProcessFrameError {
                     src: FrameFormat::RAWRGB,
@@ -253,16 +285,15 @@ pub mod channel_defs {
                 src: FrameFormat::RAWRGB,
                 destination: "OpenCV Mat".to_string(),
                 error: why.to_string(),
-            })
+            }),
         }
     }
-
 
     /// Three u8
     #[repr(transparent)]
     #[derive(Copy, Clone, Debug)]
     pub struct RGB8 {
-        pub data: [u8; 3]
+        pub data: [u8; 3],
     }
 
     unsafe impl opencv::core::DataType for RGB8 {
@@ -324,7 +355,7 @@ pub mod channel_defs {
     #[repr(transparent)]
     #[derive(Copy, Clone, Debug)]
     pub struct RGBA8 {
-        pub data: [u8; 4]
+        pub data: [u8; 4],
     }
 
     unsafe impl opencv::core::DataType for RGBA8 {

--- a/nokhwa-core/src/traits.rs
+++ b/nokhwa-core/src/traits.rs
@@ -26,7 +26,8 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 #[cfg(target_os = "macos")]
 pub type FrameRaw<'a> = Result<(Cow<'a, [u8]>, Retained<SampleBuf>), NokhwaError>;
 #[cfg(not(target_os = "macos"))]
-pub type FrameRaw = Result<Cow<[u8]>, NokhwaError>;
+pub type FrameRaw<'a> = Result<Cow<'a, [u8]>, NokhwaError>;
+#[cfg(target_os = "macos")]
 use cidre::{arc::Retained, cm::SampleBuf};
 #[cfg(feature = "wgpu-types")]
 use wgpu::{

--- a/nokhwa-core/src/traits.rs
+++ b/nokhwa-core/src/traits.rs
@@ -22,7 +22,12 @@ use crate::{
         KnownCameraControl, Resolution,
     },
 };
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, sync::Arc};
+#[cfg(target_os = "macos")]
+pub type FrameRaw<'a> = Result<(Cow<'a, [u8]>, Retained<SampleBuf>), NokhwaError>;
+#[cfg(not(target_os = "macos"))]
+pub type FrameRaw = Result<Cow<[u8]>, NokhwaError>;
+use cidre::{arc::Retained, cm::SampleBuf};
 #[cfg(feature = "wgpu-types")]
 use wgpu::{
     Device as WgpuDevice, Extent3d, ImageCopyTexture, ImageDataLayout, Queue as WgpuQueue,
@@ -37,8 +42,7 @@ use wgpu::{
 /// - Backends, if not provided with a camera format, will be spawned with 640x480@15 FPS, MJPEG [`CameraFormat`].
 /// - Behaviour can differ from backend to backend. While the Camera struct abstracts most of this away, if you plan to use the raw backend structs please read the `Quirks` section of each backend.
 /// - If you call [`stop_stream()`](CaptureBackendTrait::stop_stream()), you will usually need to call [`open_stream()`](CaptureBackendTrait::open_stream()) to get more frames from the camera.
-pub trait
-CaptureBackendTrait {
+pub trait CaptureBackendTrait {
     /// Returns the current backend used.
     fn backend(&self) -> ApiBackend;
 
@@ -164,7 +168,7 @@ CaptureBackendTrait {
     /// Will get a frame from the camera **without** any processing applied, meaning you will usually get a frame you need to decode yourself.
     /// # Errors
     /// If the backend fails to get the frame (e.g. already taken, busy, doesn't exist anymore), or [`open_stream()`](CaptureBackendTrait::open_stream()) has not been called yet, this will error.
-    fn frame_raw(&mut self) -> Result<Cow<[u8]>, NokhwaError>;
+    fn frame_raw(&mut self) -> FrameRaw;
 
     /// The minimum buffer size needed to write the current frame. If `alpha` is true, it will instead return the minimum size of the buffer with an alpha channel as well.
     /// This assumes that you are decoding to RGB/RGBA for [`FrameFormat::MJPEG`] or [`FrameFormat::YUYV`] and Luma8/LumaA8 for [`FrameFormat::GRAY`]
@@ -173,7 +177,11 @@ CaptureBackendTrait {
         let cfmt = self.camera_format();
         let resolution = cfmt.resolution();
         let pxwidth = match cfmt.format() {
-            FrameFormat::MJPEG | FrameFormat::YUYV | FrameFormat::RAWRGB | FrameFormat::RAWBGR | FrameFormat::NV12 => 3,
+            FrameFormat::MJPEG
+            | FrameFormat::YUYV
+            | FrameFormat::RAWRGB
+            | FrameFormat::RAWBGR
+            | FrameFormat::NV12 => 3,
             FrameFormat::GRAY => 1,
         };
         if alpha {

--- a/src/backends/capture/avfoundation.rs
+++ b/src/backends/capture/avfoundation.rs
@@ -1,3 +1,4 @@
+use cidre::{arc::Retained, cm::SampleBuf};
 /*
  * Copyright 2022 l1npengtul <l1npengtul@protonmail.com> / The Nokhwa Contributors
  *
@@ -54,8 +55,8 @@ pub struct AVFoundationCaptureDevice {
     info: CameraInfo,
     buffer_name: CString,
     format: CameraFormat,
-    frame_buffer_receiver: Arc<Receiver<(Vec<u8>, FrameFormat)>>,
-    fbufsnd: Arc<Sender<(Vec<u8>, FrameFormat)>>,
+    frame_buffer_receiver: Arc<Receiver<(Vec<u8>, FrameFormat, Retained<SampleBuf>)>>,
+    fbufsnd: Arc<Sender<(Vec<u8>, FrameFormat, Retained<SampleBuf>)>>,
 }
 
 #[cfg(target_os = "macos")]
@@ -121,7 +122,7 @@ impl AVFoundationCaptureDevice {
 }
 
 #[cfg(target_os = "macos")]
-impl CaptureBackendTrait for AVFoundationCaptureDevice {
+impl<'a> CaptureBackendTrait for AVFoundationCaptureDevice {
     fn backend(&self) -> ApiBackend {
         ApiBackend::AVFoundation
     }
@@ -277,19 +278,18 @@ impl CaptureBackendTrait for AVFoundationCaptureDevice {
             None => false,
         }
     }
-
     fn frame(&mut self) -> Result<Buffer, NokhwaError> {
         self.refresh_camera_format()?;
         let cfmt = self.camera_format();
         let b = self.frame_raw()?;
-        let buffer = Buffer::new(cfmt.resolution(), b.as_ref(), cfmt.format());
+        let buffer = Buffer::new(cfmt.resolution(), b.0.as_ref(), cfmt.format(), Some(b.1));
         let _ = self.frame_buffer_receiver.drain();
         Ok(buffer)
     }
 
-    fn frame_raw(&mut self) -> Result<Cow<[u8]>, NokhwaError> {
+    fn frame_raw(&mut self) -> Result<(Cow<[u8]>, Retained<SampleBuf>), NokhwaError> {
         let result = match self.frame_buffer_receiver.recv() {
-            Ok(recv) => Ok(Cow::from(recv.0)),
+            Ok((raw_buf, _, sample_buf)) => Ok((Cow::from(raw_buf), sample_buf)),
             Err(why) => Err(NokhwaError::ReadFrameError(why.to_string())),
         };
         result

--- a/src/backends/capture/msmf_backend.rs
+++ b/src/backends/capture/msmf_backend.rs
@@ -18,7 +18,7 @@ use nokhwa_core::{
     buffer::Buffer,
     error::NokhwaError,
     pixel_format::RgbFormat,
-    traits::CaptureBackendTrait,
+    traits::{CaptureBackendTrait, FrameRaw},
     types::{
         all_known_camera_controls, ApiBackend, CameraControl, CameraFormat, CameraIndex,
         CameraInfo, ControlValueSetter, FrameFormat, KnownCameraControl, RequestedFormat,
@@ -244,15 +244,21 @@ impl CaptureBackendTrait for MediaFoundationCaptureDevice {
     fn frame(&mut self) -> Result<Buffer, NokhwaError> {
         self.refresh_camera_format()?;
         let self_ctrl = self.camera_format();
+        let (bytes, sample) = self.inner.raw_bytes()?;
         Ok(Buffer::new(
             self_ctrl.resolution(),
-            &self.inner.raw_bytes()?,
+            &bytes,
             self_ctrl.format(),
+            Some(sample)
         ))
     }
 
-    fn frame_raw(&mut self) -> Result<Cow<[u8]>, NokhwaError> {
-        self.inner.raw_bytes()
+    fn frame_raw(&mut self) -> FrameRaw {
+        let raw_bytes = self.inner.raw_bytes();
+        match raw_bytes {
+            Ok((bytes, _)) => Ok((bytes)),
+            Err(why) => Err(why),
+        }
     }
 
     fn stop_stream(&mut self) -> Result<(), NokhwaError> {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use core_media_sys::CMSampleBufferRef;
 use nokhwa_core::traits::FrameRaw;
 use nokhwa_core::types::RequestedFormatType;
 use nokhwa_core::{

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use core_media_sys::CMSampleBufferRef;
+use nokhwa_core::traits::FrameRaw;
 use nokhwa_core::types::RequestedFormatType;
 use nokhwa_core::{
     buffer::Buffer,
@@ -25,6 +27,7 @@ use nokhwa_core::{
         FrameFormat, KnownCameraControl, RequestedFormat, Resolution,
     },
 };
+use std::sync::Arc;
 use std::{borrow::Cow, collections::HashMap};
 #[cfg(feature = "output-wgpu")]
 use wgpu::{Device as WgpuDevice, Queue as WgpuQueue, Texture as WgpuTexture};
@@ -384,7 +387,7 @@ impl Camera {
     /// Will get a frame from the camera **without** any processing applied, meaning you will usually get a frame you need to decode yourself.
     /// # Errors
     /// If the backend fails to get the frame (e.g. already taken, busy, doesn't exist anymore), or [`open_stream()`](CaptureBackendTrait::open_stream()) has not been called yet, this will error.
-    pub fn frame_raw(&mut self) -> Result<Cow<[u8]>, NokhwaError> {
+    pub fn frame_raw(&mut self) -> FrameRaw {
         match self.device.frame_raw() {
             Ok(f) => Ok(f),
             Err(why) => Err(why),

--- a/src/threaded.rs
+++ b/src/threaded.rs
@@ -83,6 +83,7 @@ impl CallbackCamera {
                 Resolution::new(0, 0),
                 &vec![],
                 FrameFormat::GRAY,
+                #[cfg(any(target_os = "macos", target_os = "windows"))]
                 None,
             ))),
             die_bool: Arc::new(Default::default()),
@@ -141,6 +142,7 @@ impl CallbackCamera {
             new_fmt.resolution(),
             &Vec::default(),
             self.camera_format()?.format(),
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             None,
         );
         let formats = vec![new_fmt.format()];
@@ -204,6 +206,7 @@ impl CallbackCamera {
             new_res,
             &Vec::default(),
             self.camera_format()?.format(),
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             None,
         );
         self.camera.lock().set_resolution(new_res)

--- a/src/threaded.rs
+++ b/src/threaded.rs
@@ -83,6 +83,7 @@ impl CallbackCamera {
                 Resolution::new(0, 0),
                 &vec![],
                 FrameFormat::GRAY,
+                None,
             ))),
             die_bool: Arc::new(Default::default()),
             current_camera,
@@ -140,6 +141,7 @@ impl CallbackCamera {
             new_fmt.resolution(),
             &Vec::default(),
             self.camera_format()?.format(),
+            None,
         );
         let formats = vec![new_fmt.format()];
         let request = RequestedFormat::with_formats(RequestedFormatType::Exact(new_fmt), &formats);
@@ -198,8 +200,12 @@ impl CallbackCamera {
         *self
             .last_frame_captured
             .lock()
-            .map_err(|why| NokhwaError::GeneralError(why.to_string()))? =
-            Buffer::new(new_res, &Vec::default(), self.camera_format()?.format());
+            .map_err(|why| NokhwaError::GeneralError(why.to_string()))? = Buffer::new(
+            new_res,
+            &Vec::default(),
+            self.camera_format()?.format(),
+            None,
+        );
         self.camera.lock().set_resolution(new_res)
     }
 
@@ -336,10 +342,12 @@ impl CallbackCamera {
             let camera_clone = self.camera.clone();
             let last_frame = self.last_frame_captured.clone();
             let callback = self.frame_callback.clone();
-            let handle = std::thread::spawn(move || {
-                camera_frame_thread_loop(camera_clone, callback, last_frame, die_bool_clone)
-            });
-            *handle_lock = Some(handle);
+            unsafe {
+                let handle = std::thread::spawn(move || {
+                    camera_frame_thread_loop(camera_clone, callback, last_frame, die_bool_clone)
+                });
+                *handle_lock = Some(handle);
+            }
             Ok(())
         } else {
             Err(NokhwaError::OpenStreamError(


### PR DESCRIPTION
For macos & windows.
Expose SampleBuffer / IMFSample in `Buffer` so the encoders can use them directly.